### PR TITLE
Adds PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Status
+_Use labels (`review needed`, `in progress`, or `paused`) to declare status_
+
+#### What does this PR do?
+A few sentences describing the overall goals of the pull request's commits.
+Why are we making these changes? Is there more work to be done to fully
+achieve these goals?
+
+#### Helpful background context (if appropriate)
+
+#### How can a reviewer manually see the effects of these changes?
+
+#### What are the relevant tickets?
+- https://mitlibraries.atlassian.net/browse/IDP-
+
+#### Screenshots (if appropriate)
+
+#### Todo:
+- [ ] Documentation
+- [ ] Stakeholder approval
+
+#### Requires new or updated viewers or related projects?
+YES | NO


### PR DESCRIPTION
This adds a pre-defined template for PR messages (this text you're reading) that helps to focus conversations and make sure any relevant details aren't overlooked.

[More information about PR templates can be found in GitHub's documentation](https://help.github.com/en/articles/about-issue-and-pull-request-templates), or you can look at [examples](https://github.com/MITLibraries/MITlibraries-parent/blob/master/.github/PULL_REQUEST_TEMPLATE.md) from our [other projects](https://github.com/MITLibraries/bento/blob/master/.github/PULL_REQUEST_TEMPLATE.md).